### PR TITLE
Remove with router from ResultTable Container

### DIFF
--- a/apps/search-poc/src/containers/ResultTable.tsx
+++ b/apps/search-poc/src/containers/ResultTable.tsx
@@ -21,9 +21,6 @@ const ResultTableContainer: React.FunctionComponent<{
       ),
     [props.dataQuery, props.viewId], // only trigger new call if we have a new query and a new view
   );
-  // const handleRowClick = (index, items) => {
-  //   props.history.push(`/resources/?self=${items[index].self}`);
-  // };
 
   if (error) {
     return (

--- a/apps/search-poc/src/containers/ResultTable.tsx
+++ b/apps/search-poc/src/containers/ResultTable.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useNexus } from '@bbp/react-nexus';
 import { Spin, Alert } from 'antd';
-import { withRouter, History } from 'react-router-dom';
 import ResultTable from '../components/ResultTable';
 import { getLabel, camelCaseToLabelString } from '../utils';
 
@@ -10,7 +9,7 @@ const ResultTableContainer: React.FunctionComponent<{
   orgLabel: string;
   projectLabel: string;
   viewId: string;
-  history: History;
+  handleRowClick?: (index, items) => void;
 }> = props => {
   const { loading, data, error } = useNexus<any>(
     nexus =>
@@ -22,10 +21,9 @@ const ResultTableContainer: React.FunctionComponent<{
       ),
     [props.dataQuery, props.viewId], // only trigger new call if we have a new query and a new view
   );
-
-  const handleRowClick = (index, items) => {
-    props.history.push(`/resources/?self=${items[index].self}`);
-  };
+  // const handleRowClick = (index, items) => {
+  //   props.history.push(`/resources/?self=${items[index].self}`);
+  // };
 
   if (error) {
     return (
@@ -94,11 +92,11 @@ const ResultTableContainer: React.FunctionComponent<{
           headerProperties={headerProperties}
           items={items}
           total={total}
-          onRowClick={(_, index) => handleRowClick(index, items)}
+          onRowClick={(_, index) => props.handleRowClick(index, items)}
         />
       )}
     </Spin>
   );
 };
 
-export default withRouter(ResultTableContainer);
+export default ResultTableContainer;

--- a/apps/search-poc/src/views/MainView.tsx
+++ b/apps/search-poc/src/views/MainView.tsx
@@ -1,5 +1,5 @@
-
 import * as React from 'react';
+import { withRouter, History } from 'react-router-dom';
 import Dashboards from '../containers/DashboardList';
 import ResultTable from '../containers/ResultTable';
 import { useNexus } from '@bbp/react-nexus';
@@ -11,12 +11,12 @@ import { parseNexusUrl } from '../utils';
 import WorkspaceList from '../containers/WorkspaceList';
 import './MainView.css';
 
-
 const MainView: React.FunctionComponent<{
   studioOrg: string;
   studioProject: string;
   studioViewId: string;
   studioQuery: string;
+  history: History;
 }> = props => {
   const [activeWorkspaceId, setActiveWorkspaceId] = React.useState<string>(
     null,
@@ -95,9 +95,16 @@ const MainView: React.FunctionComponent<{
           }}
         />
       )}
-      {resultTableData && <ResultTable {...resultTableData} />}
+      {resultTableData && (
+        <ResultTable
+          {...resultTableData}
+          handleRowClick={(index, items) => {
+            props.history.push(`/resources/?self=${items[index].self}`);
+          }}
+        />
+      )}
     </div>
   );
 };
 
-export default MainView;
+export default withRouter(MainView);


### PR DESCRIPTION
We need to remove the withRouter and History from those containers/components that we want to wrap as web-components