### PR TITLE
👷‍♀️ FIX: use Accept json+ld Header in Resource.get method

### DIFF
--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -27,6 +27,7 @@ describe('Resource', () => {
       await resource.get<{ name: string }>('org', 'project', 'myId', {
         rev: 1,
         q: 'myTextString',
+        as: 'n-triples',
       });
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
@@ -34,7 +35,7 @@ describe('Resource', () => {
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
       expect(fetchMock.mock.calls[0][1].headers).toEqual({
-        Accept: 'application/ld+json',
+        Accept: 'application/n-triples',
       });
     });
   });

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -24,18 +24,43 @@ describe('Resource', () => {
 
     it('should make httpGet call to the resources api with the right url and query params', async () => {
       fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
-      await resource.get<{ name: string }>('org', 'project', 'myId', {
+      await resource.get('org', 'project', 'myId', {
         rev: 1,
         q: 'myTextString',
+        format: 'expanded',
+        as: 'json',
+      });
+      await resource.get('org', 'project', 'myId', {
+        rev: 2,
         as: 'n-triples',
       });
-      expect(fetchMock.mock.calls.length).toEqual(1);
+      await resource.get('org', 'project', 'myId', {
+        rev: 3,
+        as: 'vnd.graph-viz',
+      });
+      expect(fetchMock.mock.calls.length).toEqual(3);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project/_/myId?rev=1&q=myTextString',
+        'http://api.url/v1/resources/org/project/_/myId?rev=1&q=myTextString&format=expanded',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
       expect(fetchMock.mock.calls[0][1].headers).toEqual({
+        Accept: 'application/ld+json',
+      });
+
+      expect(fetchMock.mock.calls[1][0]).toEqual(
+        'http://api.url/v1/resources/org/project/_/myId?rev=2',
+      );
+      expect(fetchMock.mock.calls[1][1].method).toEqual('GET');
+      expect(fetchMock.mock.calls[1][1].headers).toEqual({
         Accept: 'application/n-triples',
+      });
+
+      expect(fetchMock.mock.calls[2][0]).toEqual(
+        'http://api.url/v1/resources/org/project/_/myId?rev=3',
+      );
+      expect(fetchMock.mock.calls[2][1].method).toEqual('GET');
+      expect(fetchMock.mock.calls[2][1].headers).toEqual({
+        Accept: 'text/vnd.graphviz',
       });
     });
   });
@@ -48,7 +73,6 @@ describe('Resource', () => {
       expect(fetchMock.mock.calls[0][0]).toEqual(
         'http://api.url/v1/resources/org/project',
       );
-      console.log(fetchMock.mock.calls[0][1]);
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
     });
 

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -17,11 +17,14 @@ describe('Resource', () => {
         'http://api.url/v1/resources/org/project/_/myId',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
+      expect(fetchMock.mock.calls[0][1].headers).toEqual({
+        Accept: 'application/ld+json',
+      });
     });
 
     it('should make httpGet call to the resources api with the right url and query params', async () => {
       fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
-      await resource.get('org', 'project', 'myId', {
+      await resource.get<{ name: string }>('org', 'project', 'myId', {
         rev: 1,
         q: 'myTextString',
       });
@@ -30,6 +33,9 @@ describe('Resource', () => {
         'http://api.url/v1/resources/org/project/_/myId?rev=1&q=myTextString',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
+      expect(fetchMock.mock.calls[0][1].headers).toEqual({
+        Accept: 'application/ld+json',
+      });
     });
   });
 
@@ -41,6 +47,7 @@ describe('Resource', () => {
       expect(fetchMock.mock.calls[0][0]).toEqual(
         'http://api.url/v1/resources/org/project',
       );
+      console.log(fetchMock.mock.calls[0][1]);
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
     });
 

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -17,6 +17,7 @@ const Resource = (
       options?: GetResourceOptions,
     ): Promise<Resource & T> =>
       httpGet({
+        headers: { Accept: 'application/ld+json' },
         path: `${
           context.uri
         }/resources/${orgLabel}/${projectLabel}/${DEFAULT_SCHEMA_ID}/${resourceId}${buildQueryParams(

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -15,15 +15,24 @@ const Resource = (
       projectLabel: string,
       resourceId: string,
       options?: GetResourceOptions,
-    ): Promise<Resource & T> =>
-      httpGet({
-        headers: { Accept: 'application/ld+json' },
+    ): Promise<Resource & T> => {
+      const { as = 'json', ...opts } = options || {};
+      let acceptHeader = 'application/ld+json';
+      if (as === 'vnd.graph-viz') {
+        acceptHeader = 'text/vnd.graphviz';
+      }
+      if (as === 'n-triples') {
+        acceptHeader = 'application/n-triples';
+      }
+      return httpGet({
+        headers: { Accept: acceptHeader },
         path: `${
           context.uri
         }/resources/${orgLabel}/${projectLabel}/${DEFAULT_SCHEMA_ID}/${resourceId}${buildQueryParams(
-          options,
+          opts,
         )}`,
-      }),
+      });
+    },
     list: <T>(
       orgLabel: string,
       projectLabel: string,

--- a/packages/nexus-sdk/src/Resource/types.ts
+++ b/packages/nexus-sdk/src/Resource/types.ts
@@ -49,6 +49,8 @@ export type ResourceList<T> = PaginatedResource<Resource & T>;
 export type GetResourceOptions = {
   rev?: number;
   tag?: string;
+  format?: 'compacted' | 'expanded';
+  as?: 'vnd.graph-viz' | 'n-triples' | 'json';
   [key: string]: any;
 };
 


### PR DESCRIPTION
fixes https://github.com/BlueBrain/nexus/issues/760

While using `nexus.Resource.get`, the SDK will use the `Accept: application/json+ld` header so it will always fetch the resource metadata - even if it's a file