### PR TITLE
Revert "👷‍♀️FIX: getResourceOptions by adding getResourceCommonOptions"

### DIFF
--- a/packages/nexus-sdk/src/File/index.ts
+++ b/packages/nexus-sdk/src/File/index.ts
@@ -12,7 +12,7 @@ import {
   PaginatedResource,
   ResourceListOptions,
   TagResourcePayload,
-  GetResourceCommonOptions,
+  GetResourceOptions,
 } from '../Resource/types';
 import { Fetchers } from '../types';
 import { NexusContext } from '../nexusSdk';
@@ -137,7 +137,7 @@ const NexusFile = (
       orgLabel: string,
       projectLabel: string,
       fileId: string,
-      options?: GetResourceCommonOptions & { pollIntervalMs: number },
+      options?: GetResourceOptions & { pollIntervalMs: number },
     ): Observable<NexusFile> => {
       const { pollIntervalMs, ...getResourceOptions } = options;
       return poll({

--- a/packages/nexus-sdk/src/File/types.ts
+++ b/packages/nexus-sdk/src/File/types.ts
@@ -1,4 +1,4 @@
-import { Resource, GetResourceCommonOptions } from '../Resource/types';
+import { GetResourceOptions, Resource } from '../Resource/types';
 
 export type NexusFile = Resource & {
   '@type': 'File';
@@ -11,7 +11,7 @@ export type NexusFile = Resource & {
   _mediaType: string;
 };
 
-export type GetFileOptions = GetResourceCommonOptions & {
+export type GetFileOptions = GetResourceOptions & {
   as?: 'text' | 'blob' | 'document' | 'arraybuffer' | 'stream' | 'json';
 };
 

--- a/packages/nexus-sdk/src/Project/index.ts
+++ b/packages/nexus-sdk/src/Project/index.ts
@@ -8,7 +8,7 @@ import {
 } from './types';
 import { NexusContext } from '../nexusSdk';
 import { buildQueryParams } from '../utils';
-import { GetResourceCommonOptions } from '../Resource/types';
+import { GetResourceOptions } from '../Resource/types';
 
 const Project = (
   { httpGet, httpPut, httpDelete, poll }: Fetchers,
@@ -18,7 +18,7 @@ const Project = (
     get: (
       orgLabel: string,
       projectLabel: string,
-      options?: GetResourceCommonOptions,
+      options?: GetResourceOptions,
     ): Promise<Project> =>
       httpGet({
         path: `${
@@ -66,7 +66,7 @@ const Project = (
     poll: (
       orgLabel: string,
       projectLabel: string,
-      options?: GetResourceCommonOptions & { pollIntervalMs: number },
+      options?: GetResourceOptions & { pollIntervalMs: number },
     ): Observable<Project> => {
       const { pollIntervalMs, ...getProjectOptions } = options;
       return poll({

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -1,12 +1,6 @@
 import { Observable } from '@bbp/nexus-link';
-import { Fetchers, Resource } from '../types';
-import {
-  ResourceListOptions,
-  ResourcePayload,
-  ResourceList,
-  GetResourceCommonOptions,
-  GetResourceOptions,
-} from './types';
+import { Fetchers, GetResourceOptions, Resource } from '../types';
+import { ResourceListOptions, ResourcePayload, ResourceList } from './types';
 import { NexusContext } from '../nexusSdk';
 import { buildQueryParams } from '../utils';
 import { DEFAULT_SCHEMA_ID } from '../constants';
@@ -118,7 +112,7 @@ const Resource = (
       orgLabel: string,
       projectLabel: string,
       resourceId: string,
-      options?: GetResourceCommonOptions & { pollIntervalMs: number },
+      options?: GetResourceOptions & { pollIntervalMs: number },
     ): Observable<Resource & T> => {
       const { pollIntervalMs, ...getResourceOptions } = options;
       return poll({

--- a/packages/nexus-sdk/src/Resource/types.ts
+++ b/packages/nexus-sdk/src/Resource/types.ts
@@ -46,15 +46,12 @@ export type PaginatedResource<T = Resource> = {
 
 export type ResourceList<T> = PaginatedResource<Resource & T>;
 
-export type GetResourceCommonOptions = {
+export type GetResourceOptions = {
   rev?: number;
   tag?: string;
-  [key: string]: any;
-};
-
-export type GetResourceOptions = GetResourceCommonOptions & {
   format?: 'compacted' | 'expanded';
   as?: 'vnd.graph-viz' | 'n-triples' | 'json';
+  [key: string]: any;
 };
 
 export type TagResourcePayload = {

--- a/packages/nexus-sdk/src/View/index.ts
+++ b/packages/nexus-sdk/src/View/index.ts
@@ -3,10 +3,7 @@ import { Fetchers, Resource } from '../types';
 import { NexusContext } from '../nexusSdk';
 import { View, ViewList, ViewPayload, Statistics } from './types';
 import { buildQueryParams } from '../utils';
-import {
-  GetResourceCommonOptions,
-  ResourceListOptions,
-} from '../Resource/types';
+import { GetResourceOptions, ResourceListOptions } from '../Resource/types';
 
 const View = (
   { httpGet, httpPost, httpPut, httpDelete, poll }: Fetchers,
@@ -17,7 +14,7 @@ const View = (
       orgLabel: string,
       projectLabel: string,
       viewId: string,
-      options?: GetResourceCommonOptions,
+      options?: GetResourceOptions,
     ): Promise<View> =>
       httpGet({
         path: `${
@@ -83,7 +80,7 @@ const View = (
       orgLabel: string,
       projectLabel: string,
       viewId: string,
-      options?: GetResourceCommonOptions & { pollIntervalMs: number },
+      options?: GetResourceOptions & { pollIntervalMs: number },
     ): Observable<View> => {
       const { pollIntervalMs, ...getViewOptions } = options;
       return poll({


### PR DESCRIPTION
Reverts BlueBrain/nexus-js#279

This is not needed as ANY resource accepts those headers.