### PR TITLE
👷‍♀️ FIX: Archive options

### DIFF
--- a/packages/nexus-sdk/src/Archive/__tests__/index.spec.ts
+++ b/packages/nexus-sdk/src/Archive/__tests__/index.spec.ts
@@ -34,9 +34,31 @@ describe('Archive', () => {
     it('Uses a GET to the correct path', async () => {
       await archive.get('org', 'project', 'archiveId');
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/archives/org/project/archiveId?as=text',
+        'http://api.url/v1/archives/org/project/archiveId',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
+    });
+
+    it('Appends format=expanded to the url when those options are used', async () => {
+      await archive.get('org', 'project', 'archiveId', { format: 'expanded' });
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        'http://api.url/v1/archives/org/project/archiveId?format=expanded',
+      );
+      expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
+    });
+
+    it('Returns a blob when using as = "x-tar" option', async () => {
+      const mockHttpGet = jest.fn();
+      const archive = Archive(
+        {
+          ...mockFetchers,
+          httpGet: mockHttpGet,
+        },
+        { uri: 'http://api.url/v1' },
+      );
+      archive.get('org', 'project', 'archiveId', { as: 'x-tar' });
+      const { context } = mockHttpGet.mock.calls[0][0];
+      expect(context).toStrictEqual({ as: 'blob' });
     });
   });
 });

--- a/packages/nexus-sdk/src/Archive/index.ts
+++ b/packages/nexus-sdk/src/Archive/index.ts
@@ -14,9 +14,10 @@ const Archive = (
       archiveId: string,
       options?: GetArchiveOptions,
     ): Promise<Archive | Blob | string> => {
-      const opts = { as: 'text', ...options };
+      const { as, ...opts } = options || {};
       const acceptHeader =
-        opts.as === 'json' ? 'application/ld+json' : 'application/x-tar';
+        as === 'x-tar' ? 'application/x-tar' : 'application/ld+json';
+      const parseAs = as === 'x-tar' ? 'blob' : 'json';
       return httpGet({
         headers: { Accept: acceptHeader },
         path: `${
@@ -24,6 +25,9 @@ const Archive = (
         }/archives/${orgLabel}/${projectLabel}/${archiveId}${buildQueryParams(
           opts,
         )}`,
+        context: {
+          as: parseAs,
+        },
       });
     },
     create: (

--- a/packages/nexus-sdk/src/Archive/types.ts
+++ b/packages/nexus-sdk/src/Archive/types.ts
@@ -26,6 +26,7 @@ export type Archive = Resource & {
 };
 
 export type GetArchiveOptions = {
+  [key: string]: string;
   format?: 'compacted' | 'expanded';
-  as?: 'json' | 'text';
+  as?: 'json' | 'x-tar';
 };


### PR DESCRIPTION
fixes a problem where the only possible Accept property was `text`, now it's possible to fetch archives with `json` (default) as `json` or `x-tar` as a blob