### PR TITLE
Resource.create should pass schemaId

### DIFF
--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -166,7 +166,7 @@ describe('Resource', () => {
       await resource.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project',
+        'http://api.url/v1/resources/org/project/',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -190,7 +190,7 @@ describe('Resource', () => {
     it('should make httpPut call  with ResourceId to the resources api, when ResourceId is present', async () => {
       fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
       const payload = {
-        '@id': 'myResource',
+        '@id': 'resourceId',
         '@context': 'something',
         something: 'hello!',
       };
@@ -206,7 +206,7 @@ describe('Resource', () => {
     it('should make httpPut call with schemaId and ResourceId to the resources api, when schemaId and ResourceId is present', async () => {
       fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
       const payload = {
-        '@id': 'myResource',
+        '@id': 'resourceId',
         '@context': 'something',
         something: 'hello!',
       };

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -171,7 +171,7 @@ describe('Resource', () => {
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
     });
-    it('should make httpPost call with schemaID  to the resources api, when schemaId is present', async () => {
+    it('should make httpPost call with schemaId  to the resources api, when schemaId is present', async () => {
       fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
       const payload = {
         '@id': 'myResource',
@@ -185,6 +185,44 @@ describe('Resource', () => {
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
+    });
+
+    it('should make httpPut call  with ResourceId to the resources api, when ResourceId is present', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
+      const payload = {
+        '@id': 'myResource',
+        '@context': 'something',
+        something: 'hello!',
+      };
+      await resource.create('org', 'project', payload, undefined, 'resourceId');
+      expect(fetchMock.mock.calls.length).toEqual(1);
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        'http://api.url/v1/resources/org/project/_/resourceId',
+      );
+      expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
+      expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
+    });
+
+    it('should make httpPut call with schemaId and ResourceId to the resources api, when schemaId and ResourceId is present', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
+      const payload = {
+        '@id': 'myResource',
+        '@context': 'something',
+        something: 'hello!',
+      };
+      await resource.create(
+        'org',
+        'project',
+        payload,
+        'schemaId',
+        'resourceId',
+      );
+      expect(fetchMock.mock.calls.length).toEqual(1);
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        'http://api.url/v1/resources/org/project/schemaId/resourceId',
+      );
+      expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
+      expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
     });
   });
 

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -171,6 +171,21 @@ describe('Resource', () => {
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
     });
+    it('should make httpPost call with schemaID  to the resources api, when schemaId is present', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
+      const payload = {
+        '@id': 'myResource',
+        '@context': 'something',
+        something: 'hello!',
+      };
+      await resource.create('org', 'project', payload, 'schemaId');
+      expect(fetchMock.mock.calls.length).toEqual(1);
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        'http://api.url/v1/resources/org/project/schemaId',
+      );
+      expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
+      expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
+    });
   });
 
   describe('update', () => {

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -166,7 +166,7 @@ describe('Resource', () => {
       await resource.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project/',
+        'http://api.url/v1/resources/org/project',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -72,15 +72,18 @@ const Resource = (
       orgLabel: string,
       projectLabel: string,
       payload: ResourcePayload,
-      schemaId?: string,
+      schemaId: string = '_',
+      resourceId?: string,
     ): Promise<Resource> =>
-      schemaId
-        ? httpPost({
-            path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${schemaId}`,
+      resourceId
+        ? httpPut({
+            path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${schemaId}/${resourceId}`,
             body: JSON.stringify(payload),
           })
         : httpPost({
-            path: `${context.uri}/resources/${orgLabel}/${projectLabel}`,
+            path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${
+              schemaId == '_' ? '' : schemaId
+            }`,
             body: JSON.stringify(payload),
           }),
     update: (

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -81,8 +81,8 @@ const Resource = (
             body: JSON.stringify(payload),
           })
         : httpPost({
-            path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${
-              schemaId === '_' ? '' : schemaId
+            path: `${context.uri}/resources/${orgLabel}/${projectLabel}${
+              schemaId === '_' ? '' : `/${schemaId}`
             }`,
             body: JSON.stringify(payload),
           }),

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -82,7 +82,7 @@ const Resource = (
           })
         : httpPost({
             path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${
-              schemaId == '_' ? '' : schemaId
+              schemaId === '_' ? '' : schemaId
             }`,
             body: JSON.stringify(payload),
           }),

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -72,11 +72,17 @@ const Resource = (
       orgLabel: string,
       projectLabel: string,
       payload: ResourcePayload,
+      schemaId?: string,
     ): Promise<Resource> =>
-      httpPost({
-        path: `${context.uri}/resources/${orgLabel}/${projectLabel}`,
-        body: JSON.stringify(payload),
-      }),
+      schemaId
+        ? httpPost({
+            path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${schemaId}`,
+            body: JSON.stringify(payload),
+          })
+        : httpPost({
+            path: `${context.uri}/resources/${orgLabel}/${projectLabel}`,
+            body: JSON.stringify(payload),
+          }),
     update: (
       orgLabel: string,
       projectLabel: string,


### PR DESCRIPTION
Added an optional parameter to Resource.create to handle schema Id. When
it is present, create will make post call to the end point with
schema Id.

fixes BlueBrain/nexus/issues/788