### PR TITLE
Add sort type

### DIFF
--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -118,6 +118,18 @@ describe('Resource', () => {
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
     });
+
+    it('should make httpGet with sort params', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
+      await resource.list('org', 'project', {
+        sort: ['-_createdAt', '-@id'],
+      });
+      expect(fetchMock.mock.calls.length).toEqual(1);
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        'http://api.url/v1/resources/org/project?sort=-_createdAt&sort=-@id',
+      );
+      expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
+    });
   });
 
   describe('links', () => {

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -126,7 +126,7 @@ describe('Resource', () => {
       });
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project?sort=-_createdAt&sort=-@id',
+        'http://api.url/v1/resources/org/project?sort=-_createdAt&sort=-%40id',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
     });

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -49,9 +49,6 @@ const Resource = (
       options?: ResourceListOptions,
     ): Promise<ResourceList<T>> => {
       const opts = buildQueryParams(options);
-      console.log('options', options);
-      console.log('opts', opts);
-
       return httpGet({
         path: `${context.uri}/resources/${orgLabel}/${projectLabel}${opts}`,
       });

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -49,6 +49,9 @@ const Resource = (
       options?: ResourceListOptions,
     ): Promise<ResourceList<T>> => {
       const opts = buildQueryParams(options);
+      console.log('options', options);
+      console.log('opts', opts);
+
       return httpGet({
         path: `${context.uri}/resources/${orgLabel}/${projectLabel}${opts}`,
       });

--- a/packages/nexus-sdk/src/Resource/types.ts
+++ b/packages/nexus-sdk/src/Resource/types.ts
@@ -26,6 +26,7 @@ export type ResourceListOptions = {
   createdBy?: string;
   updatedBy?: string;
   schema?: string;
+  sort?: string | string[];
   [key: string]: any;
 };
 


### PR DESCRIPTION
Fixes BlueBrain/nexus#940

Updated `ResourceListOptions` with the new option:
```ts
sort?: string | string[];
```