### PR TITLE
Fix statistics type (no longer collection)

### DIFF
--- a/packages/nexus-sdk/src/View/index.ts
+++ b/packages/nexus-sdk/src/View/index.ts
@@ -187,7 +187,7 @@ const View = (
       projectLabel: string,
       viewId: string,
       projectionId: string,
-    ): Promise<PaginatedList<Statistics>> =>
+    ): Promise<Statistics> =>
       httpGet({
         path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}/${projectionId}/statistics`,
       }),
@@ -196,7 +196,7 @@ const View = (
       projectLabel: string,
       viewId: string,
       options?: { pollIntervalMs: number },
-    ): Observable<PaginatedList<Statistics>> =>
+    ): Observable<Statistics> =>
       poll({
         path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}/statistics`,
         context: { pollIntervalMs: options && options.pollIntervalMs | 1000 },

--- a/packages/nexus-sdk/src/View/types.ts
+++ b/packages/nexus-sdk/src/View/types.ts
@@ -222,4 +222,18 @@ export type Statistics = {
   processedEvents: number;
   remainingEvents: number;
   totalEvents: number;
+  values?: {
+    '@type': 'ViewStatistics';
+    sourceId: string;
+    projectionId: string;
+    totalEvents: number;
+    processedEvents: number;
+    evaluatedEvents: number;
+    remainingEvents: number;
+    discardedEvents: number;
+    failedEvents: number;
+    delayInSeconds: number;
+    lastEventDateTime: Date;
+    lastProcessedEventDateTime: Date;
+  }[];
 };


### PR DESCRIPTION
Changes statistics methods return type from `PaginatedList<Statistics>` to `Statistics` and changed the `Statistics` type to include possible `CompositeView` values collection property