### PR TITLE
add linksOverwrite property to createNexusClient options

### DIFF
--- a/packages/nexus-sdk/README.md
+++ b/packages/nexus-sdk/README.md
@@ -58,11 +58,34 @@ const nexus = createNexusClient({
 ### Middleware
 
 You can enhance the behaviour of Nexus Client with middlewares called Links.
+This will add your middleware link to the front of the execution order, but it will still
+call `triggerFetch` and `parseResponse` links at the end. This is convenient if you just need
+to add something to your payload request, such as changing headers.
 
 ```typescript
 const nexus = createNexusClient({
   uri: 'https://api.url',
   links: [someMiddleware],
+});
+```
+
+You can also use the `linksOverwrite` property to provide your own middleware, without any defaults.
+In this case, it might be useful to include the `@bbp/nexus-links` package to call `triggerFetch` and
+`parseResonse` somewhere else on the chain.
+
+This might be usefull for implementing client-side with the native Cache api.
+
+important! this will overwrite any suppled links array in the `links` property.
+
+```typescript
+const nexus = createNexusClient({
+  uri: 'https://api.url',
+  linksOverwrite: [
+    detectCache,
+    triggerFetch(fetch),
+    cacheResponse,
+    parseResponse,
+  ],
 });
 ```
 

--- a/packages/nexus-sdk/src/__tests__/nexusSDK.spec.ts
+++ b/packages/nexus-sdk/src/__tests__/nexusSDK.spec.ts
@@ -1,3 +1,5 @@
+import { Observable } from '@bbp/nexus-link';
+import { Link, Operation } from '@bbp/nexus-link/src/types';
 import { createNexusClient } from '../nexusSdk';
 
 describe('createNexusClient', () => {
@@ -9,5 +11,67 @@ describe('createNexusClient', () => {
     const nexus = createNexusClient(options);
 
     expect(nexus.context.uri).toEqual(options.uri);
+  });
+
+  it('adds a link to the front of the request handler queue from the optional links array', done => {
+    const setToken: Link = (operation: Operation, forward?: Link) => {
+      const nextOperation = {
+        ...operation,
+        headers: {
+          ...operation.headers,
+          someHeader: 'test-token',
+        },
+      };
+      return forward && forward(nextOperation);
+    };
+
+    const nexus = createNexusClient({ ...options, links: [setToken] });
+
+    fetchMock.mockResponseOnce(JSON.stringify({ hello: 'hi' }));
+
+    nexus
+      .httpGet({
+        path: 'https://someurl.com/hello',
+      })
+      .then(response => {
+        expect(fetchMock.mock.calls[0][1].headers.someHeader).toBe(
+          'test-token',
+        );
+        done();
+      });
+  });
+
+  it('calls all the links in the linksOverwrite optional array', done => {
+    const sayHi: Link = (operation: Operation, forward?: Link) => {
+      const nextOperation = {
+        ...operation,
+        context: {
+          say: 'hi',
+        },
+      };
+      return forward && forward(nextOperation);
+    };
+
+    const returnSpeech: Link = (operation: Operation) => {
+      return new Observable(subscription => {
+        subscription.next(operation.context.say);
+      });
+    };
+
+    const nexus = createNexusClient({
+      ...options,
+      linksOverwrite: [sayHi, returnSpeech],
+    });
+
+    fetchMock.mockResponseOnce(JSON.stringify({ hello: 'hi' }));
+
+    nexus
+      .httpGet({
+        path: 'https://someurl.com/hello',
+      })
+      .then(response => {
+        expect(response).toBe('hi');
+        done();
+      });
   });
 });

--- a/packages/nexus-sdk/src/nexusSdk.ts
+++ b/packages/nexus-sdk/src/nexusSdk.ts
@@ -30,6 +30,7 @@ import { getFetchInstance, getAbortControllerInstance } from './utils';
 export type NexusClientOptions = {
   uri: string;
   links?: (StatefulLink | Link)[];
+  linksOverwrite?: (StatefulLink | Link)[];
   context?: Context;
   fetch?: any; // fetch api implementation
   token?: string; // bearer token
@@ -55,8 +56,11 @@ export function createNexusClient(options: NexusClientOptions) {
   }
 
   const defaultLinks = [triggerFetch(fetchInstance), parseResponse];
+
   options.token && defaultLinks.unshift(setToken(options.token));
-  const links = options.links
+  const links = options.linksOverwrite
+    ? options.linksOverwrite
+    : options.links
     ? [...options.links, ...defaultLinks]
     : defaultLinks;
   const requestHandler = pipe(links);


### PR DESCRIPTION
This property overwrite the links used to generate the requestHandler, so that they can have full control over the links queue for things like caching and parsing.