### PR TITLE
Add consistent writes support via the indexing parameter to methods that support it

### DIFF
--- a/packages/nexus-sdk/src/File/__tests__/File.spec.ts
+++ b/packages/nexus-sdk/src/File/__tests__/File.spec.ts
@@ -153,7 +153,7 @@ describe('File', () => {
       await file.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project',
+        'http://api.url/v1/files/org/project?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(myFile);
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -170,7 +170,7 @@ describe('File', () => {
       await file.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project/myFileId',
+        'http://api.url/v1/files/org/project/myFileId?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(myFile);
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -216,7 +216,7 @@ describe('File', () => {
 
       expect(fetchMock.mock.calls.length).toEqual(2);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project',
+        'http://api.url/v1/files/org/project?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(myFile);
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -239,7 +239,7 @@ describe('File', () => {
       await file.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project/myFileId?storage=someStorageId',
+        'http://api.url/v1/files/org/project/myFileId?indexing=sync&storage=someStorageId',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(myFile);
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -259,7 +259,7 @@ describe('File', () => {
       await file.update('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project/myFileId?rev=1',
+        'http://api.url/v1/files/org/project/myFileId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(myFile);
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -303,7 +303,7 @@ describe('File', () => {
       await file.update('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project/myFileId?rev=1&storage=someStorageId',
+        'http://api.url/v1/files/org/project/myFileId?indexing=sync&rev=1&storage=someStorageId',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(myFile);
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -321,7 +321,7 @@ describe('File', () => {
       await file.link('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project',
+        'http://api.url/v1/files/org/project?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -338,7 +338,7 @@ describe('File', () => {
       await file.link('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project/myId',
+        'http://api.url/v1/files/org/project/myId?indexing=sync',
       );
       const { '@id': id, ...expected } = payload;
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(expected));
@@ -357,7 +357,7 @@ describe('File', () => {
       await file.link('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project/myId?storage=someStorageId',
+        'http://api.url/v1/files/org/project/myId?indexing=sync&storage=someStorageId',
       );
       const { '@id': id, storage, ...expected } = payload;
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(expected));
@@ -376,7 +376,7 @@ describe('File', () => {
       await file.tag('org', 'project', 'myId', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project/myId/tags?rev=1',
+        'http://api.url/v1/files/org/project/myId/tags?indexing=sync&rev=1',
       );
       const { previousRev, ...expected } = payload;
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(expected));
@@ -390,7 +390,7 @@ describe('File', () => {
       await file.deprecate('org', 'project', 'myId', 1);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/files/org/project/myId?rev=1',
+        'http://api.url/v1/files/org/project/myId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('DELETE');
     });

--- a/packages/nexus-sdk/src/File/index.ts
+++ b/packages/nexus-sdk/src/File/index.ts
@@ -6,6 +6,10 @@ import {
   LinkFilePayload,
   UpdateFilePayload,
   CreateFileOptions,
+  LinkFileOptions,
+  UpdateFileOptions,
+  DeprecateFileOptions,
+  TagFileOptions,
 } from './types';
 import { buildHeader, buildQueryParams, parseAsBuilder } from '../utils';
 import {
@@ -61,10 +65,10 @@ const NexusFile = (
       orgLabel: string,
       projectLabel: string,
       payload: FilePayload,
-      options?: CreateFileOptions,
+      options: CreateFileOptions = { indexing: 'sync' },
     ): Promise<NexusFile> => {
       const { '@id': fileId, file: body, storage } = payload;
-      const opts = buildQueryParams({ storage });
+      const opts = buildQueryParams({ storage, indexing: options.indexing });
       const headers = (options && options.extraHeaders) || {};
 
       return fileId
@@ -90,9 +94,10 @@ const NexusFile = (
       orgLabel: string,
       projectLabel: string,
       payload: LinkFilePayload,
+      options: LinkFileOptions = { indexing: 'sync' },
     ): Promise<NexusFile> => {
       const { '@id': fileId, storage, ...body } = payload;
-      const opts = buildQueryParams({ storage });
+      const opts = buildQueryParams({ storage, ...options });
       return fileId
         ? httpPut({
             body: JSON.stringify(body),
@@ -108,10 +113,14 @@ const NexusFile = (
       orgLabel: string,
       projectLabel: string,
       payload: UpdateFilePayload,
-      options?: CreateFileOptions,
+      options: UpdateFileOptions = { indexing: 'sync' },
     ): Promise<NexusFile> => {
       const { '@id': fileId, file: body, storage, rev } = payload;
-      const opts = buildQueryParams({ rev, storage });
+      const opts = buildQueryParams({
+        rev,
+        storage,
+        indexing: options.indexing,
+      });
       const headers = (options && options.extraHeaders) || {};
       return httpPut({
         headers,
@@ -124,20 +133,25 @@ const NexusFile = (
       projectLabel: string,
       fileId: string,
       rev: number,
-    ): Promise<NexusFile> =>
-      httpDelete({
-        path: `${context.uri}/files/${orgLabel}/${projectLabel}/${fileId}?rev=${rev}`,
-      }),
+      options: DeprecateFileOptions = { indexing: 'sync' },
+    ): Promise<NexusFile> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpDelete({
+        path: `${context.uri}/files/${orgLabel}/${projectLabel}/${fileId}${opts}`,
+      });
+    },
     tag: (
       orgLabel: string,
       projectLabel: string,
       fileId: string,
       payload: TagResourcePayload,
+      options: TagFileOptions = { indexing: 'sync' },
     ): Promise<NexusFile> => {
       const { previousRev, ...body } = payload;
+      const opts = buildQueryParams({ ...options, rev: previousRev });
       return httpPost({
         body: JSON.stringify(body),
-        path: `${context.uri}/files/${orgLabel}/${projectLabel}/${fileId}/tags?rev=${previousRev}`,
+        path: `${context.uri}/files/${orgLabel}/${projectLabel}/${fileId}/tags${opts}`,
       });
     },
     poll: (

--- a/packages/nexus-sdk/src/File/types.ts
+++ b/packages/nexus-sdk/src/File/types.ts
@@ -1,4 +1,5 @@
 import { Resource } from '../Resource/types';
+import { ExecutionOption } from '../types';
 
 export type NexusFile = Resource & {
   '@type': 'File';
@@ -32,9 +33,19 @@ export type FilePayload = {
   file: FormData;
 };
 
-export type CreateFileOptions = {
+export type CreateFileOptions = ExecutionOption & {
   extraHeaders?: { [key: string]: string };
 };
+
+export type UpdateFileOptions = ExecutionOption & {
+  extraHeaders?: { [key: string]: string };
+};
+
+export type DeprecateFileOptions = ExecutionOption & {};
+
+export type TagFileOptions = ExecutionOption & {};
+
+export type LinkFileOptions = ExecutionOption & {};
 
 export type UpdateFilePayload = FilePayload & {
   '@id': string; // mandatory

--- a/packages/nexus-sdk/src/Resolver/__tests__/resolver.spec.ts
+++ b/packages/nexus-sdk/src/Resolver/__tests__/resolver.spec.ts
@@ -109,7 +109,7 @@ describe('Resolver', () => {
       await resolver.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resolvers/org/project',
+        'http://api.url/v1/resolvers/org/project?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -127,7 +127,7 @@ describe('Resolver', () => {
       await resolver.update('org', 'project', 'myResolverId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resolvers/org/project/myResolverId?rev=1',
+        'http://api.url/v1/resolvers/org/project/myResolverId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -144,7 +144,7 @@ describe('Resolver', () => {
       await resolver.tag('org', 'project', 'myId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resolvers/org/project/myId?rev=1',
+        'http://api.url/v1/resolvers/org/project/myId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -157,7 +157,7 @@ describe('Resolver', () => {
       await resolver.deprecate('org', 'project', 'myId', 1);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resolvers/org/project/myId?rev=1',
+        'http://api.url/v1/resolvers/org/project/myId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('DELETE');
     });

--- a/packages/nexus-sdk/src/Resolver/index.ts
+++ b/packages/nexus-sdk/src/Resolver/index.ts
@@ -6,6 +6,10 @@ import {
   GetResolverOptions,
   ListResolverOptions,
   ResolverPayload,
+  CreateResolverOptions,
+  UpdateResolverOptions,
+  TagResolverOptions,
+  DeprecateResolverOptions,
 } from './types';
 import { NexusContext } from '../nexusSdk';
 import { buildHeader, buildQueryParams, parseAsBuilder } from '../utils';
@@ -73,9 +77,12 @@ const Resolver = (
       orgLabel: string,
       projectLabel: string,
       payload: ResolverPayload,
+      options: CreateResolverOptions = { indexing: 'sync' },
     ): Promise<Resource> =>
       httpPost({
-        path: `${context.uri}/resolvers/${orgLabel}/${projectLabel}`,
+        path: `${
+          context.uri
+        }/resolvers/${orgLabel}/${projectLabel}${buildQueryParams(options)}`,
         body: JSON.stringify(payload),
       }),
     update: (
@@ -84,9 +91,14 @@ const Resolver = (
       resolverId: string,
       rev: number,
       payload: ResolverPayload,
+      options: UpdateResolverOptions = { indexing: 'sync' },
     ): Promise<Resource> =>
       httpPut({
-        path: `${context.uri}/resolvers/${orgLabel}/${projectLabel}/${resolverId}?rev=${rev}`,
+        path: `${
+          context.uri
+        }/resolvers/${orgLabel}/${projectLabel}/${resolverId}${buildQueryParams(
+          { rev, ...options },
+        )}`,
         body: JSON.stringify(payload),
       }),
     tag: (
@@ -98,9 +110,14 @@ const Resolver = (
         tag: string;
         rev: number;
       },
+      options: TagResolverOptions = { indexing: 'sync' },
     ): Promise<Resource> =>
       httpPost({
-        path: `${context.uri}/resolvers/${orgLabel}/${projectLabel}/${resourceId}?rev=${rev}`,
+        path: `${
+          context.uri
+        }/resolvers/${orgLabel}/${projectLabel}/${resourceId}${buildQueryParams(
+          { rev, ...options },
+        )}`,
         body: JSON.stringify(payload),
       }),
     deprecate: (
@@ -108,9 +125,14 @@ const Resolver = (
       projectLabel: string,
       resolverId: string,
       rev: number,
+      options: DeprecateResolverOptions = { indexing: 'sync' },
     ): Promise<Resource> =>
       httpDelete({
-        path: `${context.uri}/resolvers/${orgLabel}/${projectLabel}/${resolverId}?rev=${rev}`,
+        path: `${
+          context.uri
+        }/resolvers/${orgLabel}/${projectLabel}/${resolverId}${buildQueryParams(
+          { rev, ...options },
+        )}`,
       }),
     poll: (
       orgLabel: string,

--- a/packages/nexus-sdk/src/Resolver/types.ts
+++ b/packages/nexus-sdk/src/Resolver/types.ts
@@ -1,4 +1,4 @@
-import { Resource, PaginatedList, Identity } from '../types';
+import { Resource, PaginatedList, Identity, IndexingOption } from '../types';
 
 export type ResolverType = 'InProject' | 'CrossProject';
 
@@ -32,6 +32,12 @@ export type ListResolverOptions = {
   createdBy?: string;
   updatedBy?: string;
 };
+
+export type CreateResolverOptions = IndexingOption & {};
+export type UpdateResolverOptions = IndexingOption & {};
+export type TagResolverOptions = IndexingOption & {};
+export type DeprecateResolverOptions = IndexingOption & {};
+
 export type ResolverPayload =
   | InProjectResolverPayload
   | CrossProjectResolverPayload;

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -182,7 +182,28 @@ describe('Resource', () => {
       await resource.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project',
+        'http://api.url/v1/resources/org/project?indexing=sync',
+      );
+      expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
+      expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
+    });
+    it('should make httpPost call to the resources api with indexing flag set to async', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
+      const payload = {
+        '@id': 'myResource',
+        '@context': {
+          label: {
+            '@id': 'http://www.w3.org/2000/01/rdf-schema#label',
+          },
+        },
+        something: 'hello!',
+      };
+      await resource.create('org', 'project', payload, undefined, undefined, {
+        indexing: 'async',
+      });
+      expect(fetchMock.mock.calls.length).toEqual(1);
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        'http://api.url/v1/resources/org/project?indexing=async',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -197,7 +218,7 @@ describe('Resource', () => {
       await resource.create('org', 'project', payload, 'schemaId');
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project/schemaId',
+        'http://api.url/v1/resources/org/project/schemaId?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -213,7 +234,7 @@ describe('Resource', () => {
       await resource.create('org', 'project', payload, undefined, 'resourceId');
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project/_/resourceId',
+        'http://api.url/v1/resources/org/project/_/resourceId?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -235,7 +256,7 @@ describe('Resource', () => {
       );
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project/schemaId/resourceId',
+        'http://api.url/v1/resources/org/project/schemaId/resourceId?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -257,7 +278,7 @@ describe('Resource', () => {
       await resource.update('org', 'project', 'myResourceId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project/_/myResourceId?rev=1',
+        'http://api.url/v1/resources/org/project/_/myResourceId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -274,7 +295,7 @@ describe('Resource', () => {
       await resource.tag('org', 'project', 'myResourceId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project/myResourceId?rev=1',
+        'http://api.url/v1/resources/org/project/myResourceId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -287,7 +308,7 @@ describe('Resource', () => {
       await resource.deprecate('org', 'project', 'myResourceId', 1);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/resources/org/project/_/myResourceId?rev=1',
+        'http://api.url/v1/resources/org/project/_/myResourceId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('DELETE');
     });

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -13,6 +13,10 @@ import {
   ResourceList,
   PaginatedList,
   ExpandedResource,
+  ResourceCreateOptions,
+  ResourceDeprecateOptions,
+  ResourceUpdateOptions,
+  ResourceTagOptions,
 } from './types';
 import { NexusContext } from '../nexusSdk';
 import { buildHeader, buildQueryParams, parseAsBuilder } from '../utils';
@@ -73,16 +77,21 @@ const Resource = (
       payload: ResourcePayload,
       schemaId: string = '_',
       resourceId?: string,
+      options: ResourceCreateOptions = { indexing: 'sync' },
     ): Promise<Resource> =>
       resourceId
         ? httpPut({
-            path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${schemaId}/${resourceId}`,
+            path: `${
+              context.uri
+            }/resources/${orgLabel}/${projectLabel}/${schemaId}/${resourceId}${buildQueryParams(
+              options,
+            )}`,
             body: JSON.stringify(payload),
           })
         : httpPost({
             path: `${context.uri}/resources/${orgLabel}/${projectLabel}${
               schemaId === '_' ? '' : `/${schemaId}`
-            }`,
+            }${buildQueryParams(options)}`,
             body: JSON.stringify(payload),
           }),
     update: (
@@ -92,12 +101,16 @@ const Resource = (
       rev: number,
       payload: ResourcePayload,
       schemaId?: string,
+      options: ResourceUpdateOptions = { indexing: 'sync' },
     ): Promise<Resource> =>
       httpPut({
         path: `${
           context.uri
         }/resources/${orgLabel}/${projectLabel}/${schemaId ||
-          DEFAULT_SCHEMA_ID}/${resourceId}?rev=${rev}`,
+          DEFAULT_SCHEMA_ID}/${resourceId}${buildQueryParams({
+          rev,
+          ...options,
+        })}`,
         body: JSON.stringify(payload),
       }),
     tag: (
@@ -109,9 +122,14 @@ const Resource = (
         tag: string;
         rev: number;
       },
+      options: ResourceTagOptions = { indexing: 'sync' },
     ): Promise<Resource> =>
       httpPost({
-        path: `${context.uri}/resources/${orgLabel}/${projectLabel}/${resourceId}?rev=${rev}`,
+        path: `${
+          context.uri
+        }/resources/${orgLabel}/${projectLabel}/${resourceId}${buildQueryParams(
+          { ...options, rev },
+        )}`,
         body: JSON.stringify(payload),
       }),
     deprecate: (
@@ -120,12 +138,16 @@ const Resource = (
       resourceId: string,
       rev: number,
       schemaId?: string,
+      options: ResourceDeprecateOptions = { indexing: 'sync' },
     ): Promise<Resource> =>
       httpDelete({
         path: `${
           context.uri
         }/resources/${orgLabel}/${projectLabel}/${schemaId ||
-          DEFAULT_SCHEMA_ID}/${resourceId}?rev=${rev}`,
+          DEFAULT_SCHEMA_ID}/${resourceId}${buildQueryParams({
+          rev,
+          ...options,
+        })}`,
       }),
     poll: <T>(
       orgLabel: string,

--- a/packages/nexus-sdk/src/Resource/types.ts
+++ b/packages/nexus-sdk/src/Resource/types.ts
@@ -1,4 +1,4 @@
-import { Context, Resource, PaginatedList } from '../types';
+import { Context, IndexingOption } from '../types';
 
 export type IncomingLink = Resource & {
   paths: string[];
@@ -29,6 +29,14 @@ export type ResourceListOptions = {
   sort?: string | string[];
   [key: string]: any;
 };
+
+export type ResourceCreateOptions = IndexingOption & {};
+
+export type ResourceUpdateOptions = IndexingOption & {};
+
+export type ResourceTagOptions = IndexingOption & {};
+
+export type ResourceDeprecateOptions = IndexingOption & {};
 
 export type ResourcePayload = {
   '@id'?: string;

--- a/packages/nexus-sdk/src/Schema/__tests__/schema.spec.ts
+++ b/packages/nexus-sdk/src/Schema/__tests__/schema.spec.ts
@@ -140,7 +140,7 @@ describe('Views', () => {
       await schema.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/schemas/org/project',
+        'http://api.url/v1/schemas/org/project?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -185,7 +185,7 @@ describe('Views', () => {
       await schema.update('org', 'project', 'myViewId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/schemas/org/project/myViewId?rev=1',
+        'http://api.url/v1/schemas/org/project/myViewId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -202,7 +202,7 @@ describe('Views', () => {
       await schema.tag('org', 'project', 'myViewId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/schemas/org/project/myViewId?rev=1',
+        'http://api.url/v1/schemas/org/project/myViewId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -215,7 +215,7 @@ describe('Views', () => {
       await schema.deprecate('org', 'project', 'myViewId', 1);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/schemas/org/project/myViewId?rev=1',
+        'http://api.url/v1/schemas/org/project/myViewId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('DELETE');
     });

--- a/packages/nexus-sdk/src/Schema/index.ts
+++ b/packages/nexus-sdk/src/Schema/index.ts
@@ -4,6 +4,7 @@ import {
   GetSchemaOptions,
   ListSchemaOptions,
   SchemaList,
+  SchemaOptions,
   SchemaPayload,
 } from './types';
 import { NexusContext } from '../nexusSdk';
@@ -49,22 +50,28 @@ const Schema = (
       orgLabel: string,
       projectLabel: string,
       payload: SchemaPayload,
-    ): Promise<Resource> =>
-      httpPost({
-        path: `${context.uri}/schemas/${orgLabel}/${projectLabel}`,
+      options: SchemaOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams(options);
+      return httpPost({
+        path: `${context.uri}/schemas/${orgLabel}/${projectLabel}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     update: (
       orgLabel: string,
       projectLabel: string,
       schemaId: string,
       rev: number,
       payload: SchemaPayload,
-    ): Promise<Resource> =>
-      httpPut({
-        path: `${context.uri}/schemas/${orgLabel}/${projectLabel}/${schemaId}?rev=${rev}`,
+      options: SchemaOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpPut({
+        path: `${context.uri}/schemas/${orgLabel}/${projectLabel}/${schemaId}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     tag: (
       orgLabel: string,
       projectLabel: string,
@@ -74,20 +81,26 @@ const Schema = (
         tag: string;
         rev: number;
       },
-    ): Promise<Resource> =>
-      httpPost({
-        path: `${context.uri}/schemas/${orgLabel}/${projectLabel}/${schemaId}?rev=${rev}`,
+      options: SchemaOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpPost({
+        path: `${context.uri}/schemas/${orgLabel}/${projectLabel}/${schemaId}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     deprecate: (
       orgLabel: string,
       projectLabel: string,
       schemaId: string,
       rev: number,
-    ): Promise<Resource> =>
-      httpDelete({
-        path: `${context.uri}/schemas/${orgLabel}/${projectLabel}/${schemaId}?rev=${rev}`,
-      }),
+      options: SchemaOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpDelete({
+        path: `${context.uri}/schemas/${orgLabel}/${projectLabel}/${schemaId}${opts}`,
+      });
+    },
     poll: (
       orgLabel: string,
       projectLabel: string,

--- a/packages/nexus-sdk/src/Schema/types.ts
+++ b/packages/nexus-sdk/src/Schema/types.ts
@@ -1,4 +1,4 @@
-import { Resource, PaginatedList, Context } from '../types';
+import { Resource, PaginatedList, Context, ExecutionOption } from '../types';
 
 export type Property = {
   datatype: string;
@@ -43,3 +43,5 @@ export type SchemaPayload = {
   '@context'?: Context;
   shapes: Shape[];
 };
+
+export type SchemaOptions = ExecutionOption & {};

--- a/packages/nexus-sdk/src/Storage/__tests__/storage.spec.ts
+++ b/packages/nexus-sdk/src/Storage/__tests__/storage.spec.ts
@@ -117,7 +117,7 @@ describe('Storage', () => {
       await storage.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/storages/org/project',
+        'http://api.url/v1/storages/org/project?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -139,7 +139,7 @@ describe('Storage', () => {
       await storage.update('org', 'project', 'myStorageId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/storages/org/project/myStorageId?rev=1',
+        'http://api.url/v1/storages/org/project/myStorageId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -156,7 +156,7 @@ describe('Storage', () => {
       await storage.tag('org', 'project', 'myViewId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/storages/org/project/myViewId?rev=1',
+        'http://api.url/v1/storages/org/project/myViewId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -169,7 +169,7 @@ describe('Storage', () => {
       await storage.deprecate('org', 'project', 'myStorageId', 1);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/storages/org/project/myStorageId?rev=1',
+        'http://api.url/v1/storages/org/project/myStorageId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('DELETE');
     });

--- a/packages/nexus-sdk/src/Storage/index.ts
+++ b/packages/nexus-sdk/src/Storage/index.ts
@@ -1,10 +1,14 @@
 import { Observable } from '@bbp/nexus-link';
 import { Fetchers } from '../types';
 import {
+  CreateStorageOptions,
+  DeprecateStorageOptions,
   GetStorageOptions,
   ListStorageOptions,
   StorageList,
   StoragePayload,
+  TagStorageOptions,
+  UpdateStorageOptions,
 } from './types';
 import { NexusContext } from '../nexusSdk';
 import { buildHeader, buildQueryParams, parseAsBuilder } from '../utils';
@@ -50,22 +54,28 @@ const Storage = (
       orgLabel: string,
       projectLabel: string,
       payload: StoragePayload,
-    ): Promise<Resource> =>
-      httpPost({
-        path: `${context.uri}/storages/${orgLabel}/${projectLabel}`,
+      options: CreateStorageOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams(options);
+      return httpPost({
+        path: `${context.uri}/storages/${orgLabel}/${projectLabel}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     update: (
       orgLabel: string,
       projectLabel: string,
       storageId: string,
       rev: number,
       payload: StoragePayload,
-    ): Promise<Resource> =>
-      httpPut({
-        path: `${context.uri}/storages/${orgLabel}/${projectLabel}/${storageId}?rev=${rev}`,
+      options: UpdateStorageOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpPut({
+        path: `${context.uri}/storages/${orgLabel}/${projectLabel}/${storageId}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     tag: (
       orgLabel: string,
       projectLabel: string,
@@ -75,20 +85,26 @@ const Storage = (
         tag: string;
         rev: number;
       },
-    ): Promise<Resource> =>
-      httpPost({
-        path: `${context.uri}/storages/${orgLabel}/${projectLabel}/${storageId}?rev=${rev}`,
+      options: TagStorageOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpPost({
+        path: `${context.uri}/storages/${orgLabel}/${projectLabel}/${storageId}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     deprecate: (
       orgLabel: string,
       projectLabel: string,
       storageId: string,
       rev: number,
-    ): Promise<Resource> =>
-      httpDelete({
-        path: `${context.uri}/storages/${orgLabel}/${projectLabel}/${storageId}?rev=${rev}`,
-      }),
+      options: DeprecateStorageOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpDelete({
+        path: `${context.uri}/storages/${orgLabel}/${projectLabel}/${storageId}${opts}`,
+      });
+    },
     poll: (
       orgLabel: string,
       projectLabel: string,

--- a/packages/nexus-sdk/src/Storage/types.ts
+++ b/packages/nexus-sdk/src/Storage/types.ts
@@ -1,4 +1,4 @@
-import { Resource, PaginatedList } from '../types';
+import { Resource, PaginatedList, ExecutionOption } from '../types';
 
 export type StorageType = 'DiskStorage' | 'RemoteDiskStorage' | 'S3Storage';
 
@@ -46,6 +46,10 @@ export type ListStorageOptions = {
   createdBy?: string;
   updatedBy?: string;
 };
+export type CreateStorageOptions = ExecutionOption & {};
+export type UpdateStorageOptions = ExecutionOption & {};
+export type TagStorageOptions = ExecutionOption & {};
+export type DeprecateStorageOptions = ExecutionOption & {};
 
 export type StoragePayload =
   | DiskStoragePayload

--- a/packages/nexus-sdk/src/View/__tests__/view.spec.ts
+++ b/packages/nexus-sdk/src/View/__tests__/view.spec.ts
@@ -129,7 +129,7 @@ describe('Views', () => {
       await view.create('org', 'project', payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/views/org/project',
+        'http://api.url/v1/views/org/project?indexing=sync',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -169,7 +169,7 @@ describe('Views', () => {
       await view.update('org', 'project', 'myViewId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/views/org/project/myViewId?rev=1',
+        'http://api.url/v1/views/org/project/myViewId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
@@ -186,7 +186,7 @@ describe('Views', () => {
       await view.tag('org', 'project', 'myViewId', 1, payload);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/views/org/project/myViewId?rev=1',
+        'http://api.url/v1/views/org/project/myViewId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].body).toEqual(JSON.stringify(payload));
       expect(fetchMock.mock.calls[0][1].method).toEqual('POST');
@@ -199,7 +199,7 @@ describe('Views', () => {
       await view.deprecate('org', 'project', 'myViewId', 1);
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
-        'http://api.url/v1/views/org/project/myViewId?rev=1',
+        'http://api.url/v1/views/org/project/myViewId?indexing=sync&rev=1',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('DELETE');
     });

--- a/packages/nexus-sdk/src/View/index.ts
+++ b/packages/nexus-sdk/src/View/index.ts
@@ -2,8 +2,12 @@ import { Observable } from '@bbp/nexus-link';
 import { Fetchers, Resource } from '../types';
 import { NexusContext } from '../nexusSdk';
 import {
+  CreateViewOptions,
+  DeprecateViewOptions,
   SparqlViewQueryResponse,
   Statistics,
+  TagViewOptions,
+  UpdateViewOptions,
   View,
   ViewList,
   ViewPayload,
@@ -53,22 +57,28 @@ const View = (
       orgLabel: string,
       projectLabel: string,
       payload: ViewPayload,
-    ): Promise<Resource> =>
-      httpPost({
-        path: `${context.uri}/views/${orgLabel}/${projectLabel}`,
+      options: CreateViewOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams(options);
+      return httpPost({
+        path: `${context.uri}/views/${orgLabel}/${projectLabel}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     update: (
       orgLabel: string,
       projectLabel: string,
       viewId: string,
       rev: number,
       payload: ViewPayload,
-    ): Promise<Resource> =>
-      httpPut({
-        path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}?rev=${rev}`,
+      options: UpdateViewOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpPut({
+        path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     tag: (
       orgLabel: string,
       projectLabel: string,
@@ -78,20 +88,26 @@ const View = (
         tag: string;
         rev: number;
       },
-    ): Promise<Resource> =>
-      httpPost({
-        path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}?rev=${rev}`,
+      options: TagViewOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpPost({
+        path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}${opts}`,
         body: JSON.stringify(payload),
-      }),
+      });
+    },
     deprecate: (
       orgLabel: string,
       projectLabel: string,
       viewId: string,
       rev: number,
-    ): Promise<Resource> =>
-      httpDelete({
-        path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}?rev=${rev}`,
-      }),
+      options: DeprecateViewOptions = { indexing: 'sync' },
+    ): Promise<Resource> => {
+      const opts = buildQueryParams({ ...options, rev });
+      return httpDelete({
+        path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}${opts}`,
+      });
+    },
     poll: (
       orgLabel: string,
       projectLabel: string,
@@ -138,10 +154,11 @@ const View = (
         },
       });
     },
-    restart: (orgLabel: string, projectLabel: string, viewId: string) =>
-      httpDelete({
+    restart: (orgLabel: string, projectLabel: string, viewId: string) => {
+      return httpDelete({
         path: `${context.uri}/views/${orgLabel}/${projectLabel}/${viewId}/progress`,
-      }),
+      });
+    },
     compositeElasticSearchQuery: <T = any>(
       orgLabel: string,
       projectLabel: string,

--- a/packages/nexus-sdk/src/View/types.ts
+++ b/packages/nexus-sdk/src/View/types.ts
@@ -1,4 +1,4 @@
-import { Resource, PaginatedList, Context } from '../types';
+import { Resource, PaginatedList, Context, IndexingOption } from '../types';
 
 export type SparqlView = Resource & {
   '@id': ['SparqlView', 'View'];
@@ -39,6 +39,11 @@ export type ElasticSearchExplanation = {
   description: string;
   details: ElasticSearchExplanation[];
 };
+
+export type CreateViewOptions = IndexingOption & {};
+export type UpdateViewOptions = IndexingOption & {};
+export type TagViewOptions = IndexingOption & {};
+export type DeprecateViewOptions = IndexingOption & {};
 
 export type ElasticSearchViewQueryResponse<T> = {
   hits: {

--- a/packages/nexus-sdk/src/types.ts
+++ b/packages/nexus-sdk/src/types.ts
@@ -10,6 +10,8 @@ export type Fetchers = {
   poll: Link;
 };
 
+export type IndexingOption = { indexing?: 'sync' | 'async' };
+
 export type Context =
   | string
   | (string | { [key: string]: any })[]


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/1395

indexing=sync|async

The parameter will default to sync if not specified. 