### PR TITLE
Support new endpoints for listing Resources across all orgs/projects or just specific a org

### DIFF
--- a/packages/nexus-link/package.json
+++ b/packages/nexus-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-link",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "A powerful, extendable way of controlling requests/responses to/from Nexus. Inspired by Apollo-link.",
   "keywords": [
     "observable",

--- a/packages/nexus-sdk/package.json
+++ b/packages/nexus-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/nexus-sdk",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "REST API abstraction for Nexus",
   "keywords": [
     "rest",
@@ -35,7 +35,7 @@
     "url": "https://github.com/BlueBrain/nexus-js/issues"
   },
   "dependencies": {
-    "@bbp/nexus-link": "^1.3.11",
+    "@bbp/nexus-link": "^1.3.12",
     "query-string": "^6.9.0"
   },
   "publishConfig": {

--- a/packages/nexus-sdk/src/Resource/README.md
+++ b/packages/nexus-sdk/src/Resource/README.md
@@ -14,7 +14,18 @@ nexus.Resource.poll('myOrg', 'myProject', 'myID', { pollTime: 3000 }).subscribe(
   d => console.log('res>', d),
 );
 
+// listing within specified organisation and project
 nexus.Resource.list('myOrg', 'myProject', { type: 'myType' })
+  .then(d => console.log('res>', d))
+  .catch(e => console.error(e));
+
+// listing within specified organisation
+nexus.Resource.list('myOrg', undefined, { type: 'myType' })
+  .then(d => console.log('res>', d))
+  .catch(e => console.error(e));
+
+// listing across all organisations/projects
+nexus.Resource.list(undefined, undefined, { type: 'myType' })
   .then(d => console.log('res>', d))
   .catch(e => console.error(e));
 

--- a/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
+++ b/packages/nexus-sdk/src/Resource/__tests__/resource.spec.ts
@@ -96,7 +96,7 @@ describe('Resource', () => {
   });
 
   describe('list', () => {
-    it('should make httpGet call to the resources api', async () => {
+    it('with both org and project label should make httpGet call to the resources api with params', async () => {
       fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
       await resource.list('org', 'project');
       expect(fetchMock.mock.calls.length).toEqual(1);
@@ -127,6 +127,24 @@ describe('Resource', () => {
       expect(fetchMock.mock.calls.length).toEqual(1);
       expect(fetchMock.mock.calls[0][0]).toEqual(
         'http://api.url/v1/resources/org/project?sort=-_createdAt&sort=-%40id',
+      );
+      expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
+    });
+
+    it('without org or project label should make httpGet call to the resources api without params', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
+      await resource.list();
+      expect(fetchMock.mock.calls.length).toEqual(1);
+      expect(fetchMock.mock.calls[0][0]).toEqual('http://api.url/v1/resources');
+      expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
+    });
+
+    it('with org label only should make httpGet call to the resources api with org param', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ data: '' }));
+      await resource.list('org');
+      expect(fetchMock.mock.calls.length).toEqual(1);
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        'http://api.url/v1/resources/org',
       );
       expect(fetchMock.mock.calls[0][1].method).toEqual('GET');
     });

--- a/packages/nexus-sdk/src/Resource/index.ts
+++ b/packages/nexus-sdk/src/Resource/index.ts
@@ -50,13 +50,24 @@ const Resource = (
       });
     },
     list: <T>(
-      orgLabel: string,
-      projectLabel: string,
+      orgLabel?: string,
+      projectLabel?: string,
       options?: ResourceListOptions,
     ): Promise<ResourceList<T>> => {
       const opts = buildQueryParams(options);
+
+      if (orgLabel) {
+        if (projectLabel) {
+          return httpGet({
+            path: `${context.uri}/resources/${orgLabel}/${projectLabel}${opts}`,
+          });
+        }
+        return httpGet({
+          path: `${context.uri}/resources/${orgLabel}${opts}`,
+        });
+      }
       return httpGet({
-        path: `${context.uri}/resources/${orgLabel}/${projectLabel}${opts}`,
+        path: `${context.uri}/resources${opts}`,
       });
     },
     links: (

--- a/packages/react-nexus/package.json
+++ b/packages/react-nexus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbp/react-nexus",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "A set of React components for Nexus",
   "keywords": [
     "react",
@@ -34,15 +34,15 @@
     "url": "https://github.com/BlueBrain/nexus-js/issues"
   },
   "dependencies": {
-    "@bbp/nexus-link": "^1.3.11",
+    "@bbp/nexus-link": "^1.3.12",
     "ts-invariant": "0.4.1"
   },
   "peerDependencies": {
-    "@bbp/nexus-sdk": "^1.3.11",
+    "@bbp/nexus-sdk": "^1.3.12",
     "react": ">= 16.8.3"
   },
   "devDependencies": {
-    "@bbp/nexus-sdk": "^1.3.11",
+    "@bbp/nexus-sdk": "^1.3.12",
     "@types/react": "^16.8.3",
     "react": "^16.8.3"
   },


### PR DESCRIPTION
Resources endpoint now supports listing resources within specific project (which was already implemented), within an organization and across all organisations.This change supports the latter two methods.

For listing resources within a specific organization:

GET /v1/resources/{org_label}?from={from}
                             &size={size}
                             &deprecated={deprecated}
                             &rev={rev}
                             &type={type}
                             &createdBy={createdBy}
                             &updatedBy={updatedBy}
                             &schema={schema}
                             &q={search}
                             &sort={sort}

For listing resources across all organizations/projects:

GET /v1/resources?from={from}
                 &size={size}
                 &deprecated={deprecated}
                 &rev={rev}
                 &type={type}
                 &createdBy={createdBy}
                 &updatedBy={updatedBy}
                 &schema={schema}
                 &q={search}
                 &sort={sort}