### PR TITLE
Add support to the AccessControl component to accept multiple paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": ["es6", "dom"],
+    "lib": ["esnext", "dom"],
     "module": "ESNext",
     "moduleResolution": "node",
     "importHelpers": true,


### PR DESCRIPTION
The AccessControl component took a single path string along with a permissions array and would determine if the those permissions were granted on the path or not. It now supports passing in an array of paths and it will determine if the array of permissions exists on each and everyone of the paths or not.